### PR TITLE
Enable ALB healthcheck endpoint

### DIFF
--- a/cerella/alb.tf
+++ b/cerella/alb.tf
@@ -40,6 +40,13 @@ resource "aws_alb_target_group" "workers" {
   port     = var.cluster-ingress-port
   protocol = "HTTP"
   vpc_id   = aws_vpc.environment.id
+  health_check {
+    enabled = true
+    healthy_threshold = 5
+    interval = 30
+    matcher = "200"
+    path = "/nginx-health"
+  }
 }
 
 resource "aws_autoscaling_attachment" "workers" {

--- a/cerella/alb.tf
+++ b/cerella/alb.tf
@@ -42,7 +42,7 @@ resource "aws_alb_target_group" "workers" {
   vpc_id   = aws_vpc.environment.id
   health_check {
     enabled = true
-    healthy_threshold = 5
+    healthy_threshold = 4
     interval = 30
     matcher = "200"
     path = "/nginx-health"

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -167,10 +167,13 @@ resource "kubernetes_namespace" "green" {
   metadata {
     annotations = {
       name = "green"
+      meta.helm.sh/release-name      = "green"
+      meta.helm.sh/release-namespace = "default"
     }
 
     labels = {
       purpose = "green"
+      app.kubernetes.io/managed-by = "Helm"
     }
 
     name = "green"

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -11,27 +11,23 @@ provider "helm" {
   }
 }
 
-variable "registry_username" {
-}
-
-variable "registry_password" {
-}
-
 resource "helm_release" "ingress" {
   name       = "ingress"
   repository = "https://helm.nginx.com/stable"
   chart      = "nginx-ingress"
   version    = var.ingress-version
-  depends_on = [aws_eks_cluster.environment]
+  depends_on = [aws_autoscaling_group.workers]
 
   set {
     name  = "controller.replicaCount"
     value = "1"
   }
+
   set {
     name  = "controller.healthStatus"
     value = "true"
   }
+
   set {
     name  = "controller.kind"
     value = "daemonset"
@@ -41,11 +37,6 @@ resource "helm_release" "ingress" {
     name  = "controller.service.type"
     value = "NodePort"
   }
-
-  #set {
-  #  name  = "controller.service.httpsPort.nodePort"
-  #  value = var.cluster-ingress-port
-  #}
 
   set {
     name  = "controller.service.httpPort.nodePort"
@@ -93,7 +84,7 @@ resource "helm_release" "prometheus" {
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
   version    = var.prometheus-version
-  depends_on = [aws_eks_cluster.environment]
+  depends_on = [aws_autoscaling_group.workers]
 }
 
 resource "helm_release" "cluster_autoscaler" {
@@ -167,13 +158,13 @@ resource "kubernetes_namespace" "green" {
   metadata {
     annotations = {
       name = "green"
-      meta.helm.sh/release-name      = "green"
-      meta.helm.sh/release-namespace = "default"
+      "meta.helm.sh/release-name"      = "green"
+      "meta.helm.sh/release-namespace" = "default"
     }
 
     labels = {
       purpose = "green"
-      app.kubernetes.io/managed-by = "Helm"
+      "app.kubernetes.io/managed-by" = "Helm"
     }
 
     name = "green"

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -28,7 +28,10 @@ resource "helm_release" "ingress" {
     name  = "controller.replicaCount"
     value = "1"
   }
-
+  set {
+    name  = "controller.healthStatus"
+    value = "true"
+  }
   set {
     name  = "controller.kind"
     value = "daemonset"

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -4,22 +4,9 @@
 #
 
 # This might be overridden
-variable "eks-instance-type" {
-  default = "t2.large"
+variable "cidr" {
+  default = "10.0.0.0/16"
   type    = string
-}
-
-# This might be overridden
-variable "eks-instance-count" {
-  default = 3
-}
-
-variable "ingress-version" {
-  default = "0.11.3"
-}
-
-variable "prometheus-version" {
-  default = "19.2.3"
 }
 
 variable "cluster-autoscaler-version" {
@@ -31,9 +18,14 @@ variable "cluster-ingress-port" {
   type    = string
 }
 
-variable "region" {
-  default = "eu-west-1"
+variable "eks-instance-type" {
+  default = "t2.large"
   type    = string
+}
+
+# This might be overridden
+variable "eks-instance-count" {
+  default = 3
 }
 
 variable "eks-version" {
@@ -46,9 +38,8 @@ variable "eks-ami" {
   type    = string
 }
 
-variable "right-availability-zone" {
-  default = "eu-west-1a"
-  type    = string
+variable "ingress-version" {
+  default = "0.11.3"
 }
 
 variable "left-availability-zone" {
@@ -56,17 +47,32 @@ variable "left-availability-zone" {
   type    = string
 }
 
-variable "cidr" {
-  default = "10.0.0.0/16"
+variable "left-subnet-cidr" {
+  default = "10.0.2.0/24"
+  type    = string
+}
+
+variable "prometheus-version" {
+  default = "19.2.3"
+}
+
+variable "region" {
+  default = "eu-west-1"
+  type    = string
+}
+
+variable "registry_username" {
+}
+
+variable "registry_password" {
+}
+
+variable "right-availability-zone" {
+  default = "eu-west-1a"
   type    = string
 }
 
 variable "right-subnet-cidr" {
   default = "10.0.1.0/24"
-  type    = string
-}
-
-variable "left-subnet-cidr" {
-  default = "10.0.2.0/24"
   type    = string
 }


### PR DESCRIPTION
Ingress ALB health check is currently failing. To fix this enabling ingress health endpoint. 
Moving Docker registry vars to variable file.
Sorting vars alphabetically in supporting_vars.tf