### PR TITLE
Adding persistent storage for Prometheus

### DIFF
--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -85,6 +85,21 @@ resource "helm_release" "prometheus" {
   chart      = "kube-prometheus-stack"
   version    = var.prometheus-version
   depends_on = [aws_autoscaling_group.workers]
+
+  set {
+    name  = "storageSpec.volumeClaimTemplate.spec.storageClassName"
+    value = "gp2"
+  }
+  set {
+    name  = "storageSpec.volumeClaimTemplate.spec.accessModes"
+    value = ["ReadWriteOnce"]
+  }
+
+  set {
+    name  = "storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+    value = "20Gi"
+  }
+
 }
 
 resource "helm_release" "cluster_autoscaler" {

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -83,7 +83,7 @@ resource "helm_release" "prometheus" {
   name       = "prometheus"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  version    = var.prometheus-version
+  version    = var.prometheus-chart-version
   depends_on = [aws_autoscaling_group.workers]
 
   set {
@@ -92,12 +92,22 @@ resource "helm_release" "prometheus" {
   }
   set {
     name  = "storageSpec.volumeClaimTemplate.spec.accessModes"
-    value = ["ReadWriteOnce"]
+    value = "[\"ReadWriteOnce\"]"
   }
 
   set {
     name  = "storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
     value = "20Gi"
+  }
+
+  set {
+    name  = "fullnameOverride"
+    value = "prometheus"
+  }
+
+  set {
+    name  = "alertmanager.enabled"
+    value = false
   }
 
 }

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -87,22 +87,17 @@ resource "helm_release" "prometheus" {
   depends_on = [aws_autoscaling_group.workers]
 
   set {
-    name  = "storageSpec.volumeClaimTemplate.spec.storageClassName"
+    name  = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName"
     value = "gp2"
   }
   set {
-    name  = "storageSpec.volumeClaimTemplate.spec.accessModes"
-    value = "[\"ReadWriteOnce\"]"
+    name  = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes[0]"
+    value = "ReadWriteOnce"
   }
 
   set {
-    name  = "storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+    name  = "prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
     value = "20Gi"
-  }
-
-  set {
-    name  = "fullnameOverride"
-    value = "prometheus"
   }
 
   set {

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -69,8 +69,8 @@ variable "left-subnet-cidr" {
   type    = string
 }
 
-variable "prometheus-version" {
-  default = "19.2.3"
+variable "prometheus-chart-version" {
+  default = "38.0.0"
 }
 
 variable "region" {


### PR DESCRIPTION
Current implementation of  prometheus pods is using local storage, due to this, Cluster autoscaler is not able  to delete nodes while scaling down. To avoid this and also to keep metrics persistent adding persistent volume.

Upgrading prometheus chart version to latest.

Disabling alert manager creation as we are not using it.