### PR TITLE
QA EKS Upgrade v1.21

### DIFF
--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -3,10 +3,17 @@
 # @date Feb 2022
 #
 
+resource "aws_ebs_encryption_by_default" "ebs_encryption" {
+  enabled = true
+}
+
 resource "aws_eks_cluster" "environment" {
   name     = var.cluster-name
   role_arn = aws_iam_role.control_plane.arn
   version  = var.eks-version
+  depends_on = [
+    aws_ebs_encryption_by_default.ebs_encryption
+  ]
 
   vpc_config {
     security_group_ids = [aws_security_group.control_plane.id]
@@ -151,7 +158,7 @@ resource "aws_eks_addon" "kube_proxy" {
   addon_name        = "kube-proxy"
   addon_version     = var.kube_proxy_addon_version
   resolve_conflicts = "OVERWRITE"
-  depends_on      = [aws_eks_cluster.environment]
+  depends_on        = [aws_eks_cluster.environment]
 }
 
 # Kube Proxy
@@ -160,7 +167,7 @@ resource "aws_eks_addon" "vpc_cni" {
   addon_name        = "vpc-cni"
   addon_version     = var.vpc_cni_addon_version
   resolve_conflicts = "OVERWRITE"
-  depends_on      = [aws_eks_cluster.environment]
+  depends_on        = [aws_eks_cluster.environment]
 }
 
 # Coredns
@@ -169,5 +176,5 @@ resource "aws_eks_addon" "coredns" {
   addon_name        = "coredns"
   addon_version     = var.coredns_addon_version
   resolve_conflicts = "OVERWRITE"
-  depends_on      = [aws_eks_cluster.environment]
+  depends_on        = [aws_eks_cluster.environment]
 }

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -21,10 +21,21 @@ resource "aws_eks_cluster" "environment" {
   }
 }
 
+data "aws_ami" "eks_ami" {
+
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${var.eks-version}-v*"]
+  }
+
+  most_recent = true
+  owners      = ["amazon"]
+}
+
 resource "aws_launch_configuration" "workers" {
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.worker_nodes.name
-  image_id                    = var.eks-ami
+  image_id                    = data.aws_ami.eks_ami[0].image_id
   instance_type               = var.eks-instance-type
   key_name                    = "cerella-${var.cluster-name}"
   name_prefix                 = "eks_workers"

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -160,3 +160,11 @@ resource "aws_eks_addon" "vpc_cni" {
   addon_version     = var.vpc_cni_addon_version
   resolve_conflicts = "OVERWRITE"
 }
+
+# Coredns
+resource "aws_eks_addon" "coredns" {
+  cluster_name      = aws_eks_cluster.environment.name
+  addon_name        = "coredns"
+  addon_version     = var.coredns_addon_version
+  resolve_conflicts = "OVERWRITE"
+}

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -143,3 +143,18 @@ locals {
   provider_url = replace(flatten(concat(aws_eks_cluster.environment[*].identity[*].oidc.0.issuer, [""]))[0], "https://", "")
   depends_on   = [aws_iam_openid_connect_provider.oidc_identity_provider]
 }
+
+# Addon
+# Kube Proxy
+
+data "aws_eks_addon" "kube_proxy" {
+  addon_name         = "kube-proxy"
+  cluster_name = aws_eks_cluster.environment.name
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name  = aws_eks_cluster.environment.name
+  addon_name    = "kube-proxy"
+  addon_version = data.aws_eks_addon.kube_proxy.addon_version
+  resolve_conflicts = "OVERWRITE"
+}

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -35,7 +35,7 @@ data "aws_ami" "eks_ami" {
 resource "aws_launch_configuration" "workers" {
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.worker_nodes.name
-  image_id                    = data.aws_ami.eks_ami[0].image_id
+  image_id                    = data.aws_ami.eks_ami.image_id
   instance_type               = var.eks-instance-type
   key_name                    = "cerella-${var.cluster-name}"
   name_prefix                 = "eks_workers"

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -147,14 +147,13 @@ locals {
 # Addon
 # Kube Proxy
 
-data "aws_eks_addon" "kube_proxy" {
+data "aws_eks_addon_version" "kube_proxy" {
   addon_name         = "kube-proxy"
-  cluster_name = aws_eks_cluster.environment.name
+  kubernetes_version = aws_eks_cluster.environment.version
 }
-
 resource "aws_eks_addon" "kube_proxy" {
-  cluster_name  = aws_eks_cluster.environment.name
-  addon_name    = "kube-proxy"
-  addon_version = data.aws_eks_addon.kube_proxy.addon_version
+  cluster_name      = aws_eks_cluster.environment.name
+  addon_name        = "kube-proxy"
+  addon_version     = data.aws_eks_addon_version.kube_proxy.version
   resolve_conflicts = "OVERWRITE"
 }

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -146,14 +146,9 @@ locals {
 
 # Addon
 # Kube Proxy
-
-data "aws_eks_addon_version" "kube_proxy" {
-  addon_name         = "kube-proxy"
-  kubernetes_version = aws_eks_cluster.environment.version
-}
 resource "aws_eks_addon" "kube_proxy" {
   cluster_name      = aws_eks_cluster.environment.name
   addon_name        = "kube-proxy"
-  addon_version     = data.aws_eks_addon_version.kube_proxy.version
+  addon_version     = var.kube_proxy_addon_version
   resolve_conflicts = "OVERWRITE"
 }

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -151,6 +151,7 @@ resource "aws_eks_addon" "kube_proxy" {
   addon_name        = "kube-proxy"
   addon_version     = var.kube_proxy_addon_version
   resolve_conflicts = "OVERWRITE"
+  depends_on      = [aws_eks_cluster.environment]
 }
 
 # Kube Proxy
@@ -159,6 +160,7 @@ resource "aws_eks_addon" "vpc_cni" {
   addon_name        = "vpc-cni"
   addon_version     = var.vpc_cni_addon_version
   resolve_conflicts = "OVERWRITE"
+  depends_on      = [aws_eks_cluster.environment]
 }
 
 # Coredns
@@ -167,4 +169,5 @@ resource "aws_eks_addon" "coredns" {
   addon_name        = "coredns"
   addon_version     = var.coredns_addon_version
   resolve_conflicts = "OVERWRITE"
+  depends_on      = [aws_eks_cluster.environment]
 }

--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -152,3 +152,11 @@ resource "aws_eks_addon" "kube_proxy" {
   addon_version     = var.kube_proxy_addon_version
   resolve_conflicts = "OVERWRITE"
 }
+
+# Kube Proxy
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name      = aws_eks_cluster.environment.name
+  addon_name        = "vpc-cni"
+  addon_version     = var.vpc_cni_addon_version
+  resolve_conflicts = "OVERWRITE"
+}

--- a/cerella/main.tf
+++ b/cerella/main.tf
@@ -2,22 +2,22 @@ module "external_secret_iam_policy" {
   source        = "./modules/iam/iam-policy"
   create_policy = true
   description   = "IAM Policy for external secrets."
-  name_prefix = "external-secret-"
+  name_prefix   = "external-secret-"
   policy_statements = [
     {
       sid = "SecretManagerAccess"
 
-      effect    = "Allow"
-      actions   = [
+      effect = "Allow"
+      actions = [
         "sts:AssumeRoleWithWebIdentity",
         "secretsmanager:GetResourcePolicy",
         "secretsmanager:GetSecretValue",
         "secretsmanager:DescribeSecret",
         "secretsmanager:ListSecretVersionIds"
-        ]
+      ]
       resources = [
         "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:CERELLA_*"
-        ]
+      ]
     }
   ]
 }
@@ -42,19 +42,19 @@ module "ingest_iam_policy" {
   source        = "./modules/iam/iam-policy"
   create_policy = true
   description   = "IAM Policy for ingest service."
-  name_prefix          = "ingest-policy-"
+  name_prefix   = "ingest-policy-"
   policy_statements = [
     {
       sid = "kmsAccess"
 
-      effect    = "Allow"
-      actions   = [
+      effect = "Allow"
+      actions = [
         "kms:Encrypt",
         "kms:Decrypt"
-        ]
+      ]
       resources = [
         module.ingest_kms_key.key_arn
-        ]
+      ]
     }
   ]
 }

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -141,6 +141,6 @@ variable "vpc_cni_addon_version" {
 }
 
 variable "coredns_addon_version" {
-  default = "v1.8.7-eksbuild.2"
+  default = "v1.8.3-eksbuild.1"
   type    = string
 }

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -129,7 +129,13 @@ variable "external_secret_service_account_name" {
   type    = string
 }
 
+# Get addon version value by running aws eks describe-addon-versions
 variable "kube_proxy_addon_version" {
   default = "v1.20.15-eksbuild.2"
+  type    = string
+}
+
+variable "vpc_cni_addon_version" {
+  default = "v1.11.3-eksbuild.1"
   type    = string
 }

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -139,3 +139,8 @@ variable "vpc_cni_addon_version" {
   default = "v1.11.3-eksbuild.1"
   type    = string
 }
+
+variable "coredns_addon_version" {
+  default = "v1.8.7-eksbuild.2"
+  type    = string
+}

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -128,3 +128,8 @@ variable "external_secret_service_account_name" {
   default = "external-secrets"
   type    = string
 }
+
+variable "kube_proxy_addon_version" {
+  default = "v1.20.15-eksbuild.2"
+  type    = string
+}

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -26,10 +26,10 @@ variable "domain" {
   type = string
 }
 
-variable "eks-ami" {
-  default = "ami-0fd784d3523cda0fa"
-  type    = string
-}
+# variable "eks-ami" {
+#   default = "ami-0fd784d3523cda0fa"
+#   type    = string
+# }
 
 # This might be overridden
 variable "eks-instance-count" {

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -10,7 +10,7 @@ variable "cidr" {
 }
 
 variable "cluster-autoscaler-version" {
-  default = "v1.22.0"
+  default = "v1.21.3"
 }
 
 variable "cluster-ingress-port" {
@@ -42,7 +42,7 @@ variable "eks-instance-type" {
 }
 
 variable "eks-version" {
-  default = "1.22"
+  default = "1.21"
   type    = string
 }
 
@@ -131,7 +131,7 @@ variable "external_secret_service_account_name" {
 
 # Get addon version value by running aws eks describe-addon-versions
 variable "kube_proxy_addon_version" {
-  default = "v1.20.15-eksbuild.2"
+  default = "v1.21.14-eksbuild.2"
   type    = string
 }
 
@@ -141,6 +141,6 @@ variable "vpc_cni_addon_version" {
 }
 
 variable "coredns_addon_version" {
-  default = "v1.8.3-eksbuild.1"
+  default = "v1.8.4-eksbuild.1"
   type    = string
 }


### PR DESCRIPTION
Enable Addons:

- When EKS cluster get created, by default AWS deploys some Kubernetes components like kube-proxy, CNI, CoreDNS into the cluster.
- When we upgrade EKS to new version these components are also need upgrade. 
- As these are not deployed by us we don't own manifest files and normally upgrade involves manual steps of patching these components to newer version. 
- To avoid manual steps, enabling EKS addons for these components. 

Removing hardcoded ami-id. 
Enabling EBS encryption setting at account level.

Note: Once this MR is merged , I will create new MR for upgrading cluster to 1.22