### PR TITLE
Allowing to pass Helm override value file 

### DIFF
--- a/cerella/eks.tf
+++ b/cerella/eks.tf
@@ -199,7 +199,7 @@ module "eks_ingest_workers_asg" {
   eks_cluster_ca_cert         = aws_eks_cluster.environment.certificate_authority.0.data
   eks_cluster_region          = var.region
   instance_type               = var.ingest-instance-type
-  disk_size                   = "20"
+  disk_size                   = "100"
   disk_type                   = "gp2"
   apply_taints                = true
   node_taints                 = { node = "ingest:NoSchedule" }

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -262,6 +262,7 @@ resource "helm_release" "cerella_elasticsearch" {
   chart      = "cerella_elasticsearch"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_eck]
+  values     = [ var.override_elasticsearch_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
   set {
     name  = "domain"
     value = var.domain
@@ -275,7 +276,7 @@ resource "helm_release" "cerella_blue" {
   chart      = "cerella_blue"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
-
+  values     = [ var.override_blue_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
   set {
     name  = "domain"
     value = var.domain
@@ -294,6 +295,7 @@ resource "helm_release" "cerella_green" {
   chart      = "cerella_green"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
+  values     = [ var.override_green_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
 
   set {
     name  = "domain"

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -262,7 +262,7 @@ resource "helm_release" "cerella_elasticsearch" {
   chart      = "cerella_elasticsearch"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_eck]
-  values     = [ var.elasticsearch_override_file_name ? "${file("helm-override-values/${var.elasticsearch_override_file_name}")}" : null ]
+  values     = var.elasticsearch_override_file_name != "" ? ["${file("helm-override-values/${var.elasticsearch_override_file_name}")}"] : []
   set {
     name  = "domain"
     value = var.domain
@@ -276,7 +276,7 @@ resource "helm_release" "cerella_blue" {
   chart      = "cerella_blue"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
-  values     =  var.cerella_blue_override_file_name ? ["${file("helm-override-values/${var.cerella_blue_override_file_name}")}"  ] : null
+  values     =  var.cerella_blue_override_file_name != "" ? ["${file("helm-override-values/${var.cerella_blue_override_file_name}")}"] : []
   set {
     name  = "domain"
     value = var.domain
@@ -295,7 +295,7 @@ resource "helm_release" "cerella_green" {
   chart      = "cerella_green"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
-  values     = [ var.cerella_green_override_file_name ? "${file("helm-override-values/${var.cerella_green_override_file_name}")}" : null ]
+  values     = var.cerella_green_override_file_name != "" ? ["${file("helm-override-values/${var.cerella_green_override_file_name}")}"] : []
 
   set {
     name  = "domain"

--- a/cerella/helm.tf
+++ b/cerella/helm.tf
@@ -262,7 +262,7 @@ resource "helm_release" "cerella_elasticsearch" {
   chart      = "cerella_elasticsearch"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_eck]
-  values     = [ var.override_elasticsearch_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
+  values     = [ var.elasticsearch_override_file_name ? "${file("helm-override-values/${var.elasticsearch_override_file_name}")}" : null ]
   set {
     name  = "domain"
     value = var.domain
@@ -276,7 +276,7 @@ resource "helm_release" "cerella_blue" {
   chart      = "cerella_blue"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
-  values     = [ var.override_blue_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
+  values     =  var.cerella_blue_override_file_name ? ["${file("helm-override-values/${var.cerella_blue_override_file_name}")}"  ] : null
   set {
     name  = "domain"
     value = var.domain
@@ -295,7 +295,7 @@ resource "helm_release" "cerella_green" {
   chart      = "cerella_green"
   version    = var.cerella-version
   depends_on = [helm_release.cerella_elasticsearch]
-  values     = [ var.override_green_defaults ? "${file("override-values/${var.override_file_name}")}" : null ]
+  values     = [ var.cerella_green_override_file_name ? "${file("helm-override-values/${var.cerella_green_override_file_name}")}" : null ]
 
   set {
     name  = "domain"

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -162,3 +162,15 @@ variable "ingest_node_desired_capacity" {
 variable "ingest-instance-type" {
   type = string
 }
+
+variable "elasticsearch_override_file_name" {
+  type    = string
+}
+
+variable "cerella_blue_override_file_name" {
+  type    = string
+}
+
+variable "cerella_green_override_file_name" {
+  type    = string
+}

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -164,19 +164,19 @@ variable "ingest-instance-type" {
 }
 
 variable "elasticsearch_override_file_name" {
-  # if empty, then helm release will not use file to overirde default values
+  # if empty, then helm release will not use file to override default values
   type    = string
   default = ""
 }
 
 variable "cerella_blue_override_file_name" {
-  # if empty, then helm release will not use file to overirde default values
+  # if empty, then helm release will not use file to override default values
   type    = string
   default = ""
 }
 
 variable "cerella_green_override_file_name" {
-  # if empty, then helm release will not use file to overirde default values
+  # if empty, then helm release will not use file to override default values
   type    = string
   default = ""
 }

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -164,13 +164,19 @@ variable "ingest-instance-type" {
 }
 
 variable "elasticsearch_override_file_name" {
+  # if empty, then helm release will not use file to overirde default values
   type    = string
+  default = ""
 }
 
 variable "cerella_blue_override_file_name" {
+  # if empty, then helm release will not use file to overirde default values
   type    = string
+  default = ""
 }
 
 variable "cerella_green_override_file_name" {
+  # if empty, then helm release will not use file to overirde default values
   type    = string
+  default = ""
 }

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -162,3 +162,19 @@ variable "ingest_node_desired_capacity" {
 variable "ingest-instance-type" {
   type = string
 }
+
+variable "override_elasticsearch_defaults" {
+  default = false
+}
+
+variable "override_blue_defaults" {
+  default = false
+}
+
+variable "override_green_defaults" {
+  default = false
+}
+
+variable "override_file_name" {
+  type    = string
+}

--- a/cerella/supporting_vars.tf
+++ b/cerella/supporting_vars.tf
@@ -162,19 +162,3 @@ variable "ingest_node_desired_capacity" {
 variable "ingest-instance-type" {
   type = string
 }
-
-variable "override_elasticsearch_defaults" {
-  default = false
-}
-
-variable "override_blue_defaults" {
-  default = false
-}
-
-variable "override_green_defaults" {
-  default = false
-}
-
-variable "override_file_name" {
-  type    = string
-}


### PR DESCRIPTION
Currently override values  for Helm charts are stored in the files here : https://github.com/optibrium/cerella/tree/master/helm/cerella_green/override-values and https://github.com/optibrium/cerella/tree/master/helm/cerella_blue/override-values

These file are getting packaged with charts and uploaded to Helm repo. So every time change in override value requires update in helm chart version. 
To avoid this,  allowing to  pass value file with Terraform execution.
Example : https://github.com/optibrium/infra/pull/40/files
